### PR TITLE
Improve init readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Jidesha
 =======
 
-Extension for Firefox and Chrome for Desktop Sharing in Jitsi Meet.
+Extension for [Firefox](https://github.com/jitsi/jidesha/blob/master/firefox/README.md) and [Chrome](https://github.com/jitsi/jidesha/blob/master/chrome/README.md) for Desktop Sharing in Jitsi Meet.


### PR DESCRIPTION
For me was not clear to think that I have to enter `chrome` and `firefox` directories to see the corresponding `README`  and/or documentation. Seems that Google search does not have it clear too (or I was not using good keywords in the search), because pointed me to mailing list, github issues, etc. but not these places (I tried several times in several dates). Now that I know, yes, it is so obvious. But for new people, I would like to help them.