### PR TITLE
Add update_url to manifest.json

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,9 +1,10 @@
 {
   "manifest_version": 2,
   "name": "Jitsi Desktop Streamer",
+  "update_url": "http://myhost.com/mytestextension/updates.xml",
   "description": "A simple extension that allows you to stream your desktop into meetings with Jitsi Meet and Jitsi Videobridge.",
-  "version": "0.1.6",
-  "minimum_chrome_version": "34",
+  "version": "0.1.7",
+  "minimum_chrome_version": "63",
   "icons": {
     "16": "jitsi-logo-16x16.png",
     "48": "jitsi-logo-48x48.png",

--- a/chrome/updates-example.xml
+++ b/chrome/updates-example.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+  <app appid='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'>
+    <updatecheck codebase='http://myhost.com/mytestextension/mte_v2.crx' version='2.0' />
+  </app>
+</gupdate>


### PR DESCRIPTION
Starting with Chrome 63 it is now required to have update_url filed in manifest.json. Without that filed Chrome will show "This extension may have been corrupted."

More information can be found at: https://developer.chrome.com/apps/autoupdate