### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/calendar/meet-calendar.js
+++ b/calendar/meet-calendar.js
@@ -1090,7 +1090,7 @@ function findGetParameter(parameterName) {
     var result = null,
         tmp = [];
     location.search
-        .substr(1)
+        .slice(1)
         .split("&")
         .forEach(function (item) {
             tmp = item.split("=");


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.